### PR TITLE
make it work both manually, and with defaults based on

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,7 @@
+# if VARNISHSRC is defined on the command-line, use that. Otherwise, build
+# this the same as the modules that come with varnish (i.e. we're building
+# within the varnish src dir itself, and $(top_srcdir) is the varnish source).
+#
 ifdef $(VARNISHSRC):
 	SRC = $(VARNISHSRC)
 	DIR_PREFIX = /

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,17 @@
-INCLUDES = -I$(VARNISHSRC)/include -I$(VARNISHSRC)
+ifdef $(VARNISHSRC):
+	SRC = $(VARNISHSRC)
+	DIR_PREFIX = /
+else:
+	SRC = $(top_srcdir)
+	DIR_PREFIX = lib/libvmod-timers/
 
-vmoddir = $(VMODDIR)
+INCLUDES = -I$(SRC)/include -I$(SRC)
+
+ifdef $(VMODDIR):
+	vmoddir = $(VMODDIR)
+else:
+	vmoddir = $(pkglibdir)/vmods
+
 vmod_LTLIBRARIES = libvmod_timers.la
 
 libvmod_timers_la_LDFLAGS = -module -export-dynamic -avoid-version
@@ -10,14 +21,14 @@ libvmod_timers_la_SOURCES = \
 	vcc_if.h \
 	vmod_timers.c
 
-vcc_if.c vcc_if.h: $(VARNISHSRC)/lib/libvmod_std/vmod.py $(top_srcdir)/src/vmod_timers.vcc
-	@PYTHON@ $(VARNISHSRC)/lib/libvmod_std/vmod.py $(top_srcdir)/src/vmod_timers.vcc
+vcc_if.c vcc_if.h: $(SRC)/lib/libvmod_std/vmod.py $(top_srcdir)/$(DIR_PREFIX)src/vmod_timers.vcc
+	@PYTHON@ $(SRC)/lib/libvmod_std/vmod.py $(top_srcdir)/$(DIR_PREFIX)src/vmod_timers.vcc
 
 VMOD_TESTS = tests/*.vtc
 .PHONY: $(VMOD_TESTS)
 
 tests/*.vtc:
-	$(VARNISHSRC)/bin/varnishtest/varnishtest -Dvarnishd=$(VARNISHSRC)/bin/varnishd/varnishd -Dvmod_topbuild=$(abs_top_builddir) $@
+	$(SRC)/bin/varnishtest/varnishtest -Dvarnishd=$(top_srcdir)/bin/varnishd/varnishd -Dvmod_topbuild=$(abs_top_builddir) $@
 
 check: $(VMOD_TESTS)
 


### PR DESCRIPTION
building as part of varnish (where we've included this as a subtree in varnish's lib/ dir)
