### PR TITLE
use SRC variable also in the binary command parameter

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,7 +34,7 @@ VMOD_TESTS = tests/*.vtc
 .PHONY: $(VMOD_TESTS)
 
 tests/*.vtc:
-	$(SRC)/bin/varnishtest/varnishtest -Dvarnishd=$(top_srcdir)/bin/varnishd/varnishd -Dvmod_topbuild=$(abs_top_builddir) $@
+	$(SRC)/bin/varnishtest/varnishtest -Dvarnishd=$(SRC)/bin/varnishd/varnishd -Dvmod_topbuild=$(abs_top_builddir) $@
 
 check: $(VMOD_TESTS)
 


### PR DESCRIPTION
`make check` fails when using VARNISHSRC variable
