### PR TITLE
Add dependency on vcc_if.h, to fix concurrent build issue

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,6 +27,9 @@ libvmod_timers_la_SOURCES = \
 	vcc_if.h \
 	vmod_timers.c
 
+# Needed to stop concurrent builds from failing
+vmod_timers.lo: vcc_if.h
+
 vcc_if.c vcc_if.h: $(SRC)/lib/libvmod_std/vmod.py $(top_srcdir)/$(DIR_PREFIX)src/vmod_timers.vcc
 	@PYTHON@ $(SRC)/lib/libvmod_std/vmod.py $(top_srcdir)/$(DIR_PREFIX)src/vmod_timers.vcc
 


### PR DESCRIPTION
Sometimes building with make -j<something greater than 1> fails, because it can't find vcc_if.h

Adding a dependency on it should help this problem.
